### PR TITLE
add 'get role' to swagger documentation

### DIFF
--- a/public/api-docs.json
+++ b/public/api-docs.json
@@ -802,6 +802,23 @@
           }
         }
       }
+    },
+    "/v1/roles": {
+      "get": {
+        "tags": ["Roles"],
+        "summary": "Get roles",
+        "description": "Get roles",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Roles retrieved successfully"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?
add 'get role' to swagger documentation

## How to test it
- run `git pull`
- run `npm run dev` to start the server
- at `localhost:8001/api-docs` test the GET API under the Roles tag

## Screenshots
![image](https://user-images.githubusercontent.com/66947850/185371058-16fccde7-475a-4bb0-a1f2-c471023c6d77.png)
